### PR TITLE
Issue #15: support for phantom v2.x

### DIFF
--- a/lib/phantomscript.js
+++ b/lib/phantomscript.js
@@ -42,7 +42,13 @@ phantom args sent from grunticon.js:
 		throw new Error( reason );
 	});
 
-	var options = {
+	// alternate syntax for PhantomJS 2.x (system.args) / 1.x (phantom.args)
+	var options = (typeof(phantom.args) === "undefined") ? {
+		inputFiles: JSON.parse(system.args[1]),
+		dest: system.args[2],
+		defaultWidth: system.args[3],
+		defaultHeight: system.args[4]
+	} : {
 		inputFiles: JSON.parse(phantom.args[0]),
 		dest: phantom.args[1],
 		defaultWidth: phantom.args[2],

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "test": "grunt nodeunit"
   },
   "dependencies": {
-    "phantomjs": "~1.9.13"
+    "phantomjs": "^2.1.7"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-contrib-qunit": "~0.3.0",
-    "grunt-contrib-watch": "~0.2.0",
-    "grunt": "~0.4.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-qunit": "^1.2.0",
+    "grunt-contrib-watch": "^1.0.0",
     "phantom-unit": "0.1.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Hi,

this has come up on grunticon https://github.com/filamentgroup/grunticon/issues/315 but it belongs here to svg-to-png.
Phantomjs v2.x changes the way arguments are passed to the executable. The new syntax is backwards compatible (should you choose not to merge package.json which updates all packages to the current version).

Test run and passing.