### PR TITLE
Upgrade imagemin to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "phantom-unit": "^1.0.1"
   },
   "optionalDependencies": {
-    "imagemin": "3.1.0"
+    "imagemin": "4.0.0"
   },
   "keywords": []
 }


### PR DESCRIPTION
This version upgrades its `vinyl-fs` dependency to ^2.1.1 which itself upgrades its `graceful-fs` dependency to ^4.0.0 which is needed for Node >=7 support.

See npm warning:
> npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v 7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
